### PR TITLE
Fix volume when max_volume != 100

### DIFF
--- a/custom_components/musiccast_yamaha/media_player.py
+++ b/custom_components/musiccast_yamaha/media_player.py
@@ -145,7 +145,6 @@ class YamahaDevice(MediaPlayerEntity):
         self.power = STATE_UNKNOWN
         self.status = STATE_UNKNOWN
         self.volume = 0
-        self.volume_max = 0
         self._recv.set_yamaha_device(self)
         self._zone.set_yamaha_device(self)
 
@@ -330,9 +329,8 @@ class YamahaDevice(MediaPlayerEntity):
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
-        _LOGGER.debug("Volume level: %.2f / %d",
-                      volume, volume * self.volume_max)
-        self._zone.set_volume(volume * self.volume_max)
+        _LOGGER.debug("Volume level: %.2f", volume)
+        self._zone.set_volume(volume * 100)
 
     def select_source(self, source):
         """Send the media player the command to select input source."""

--- a/custom_components/musiccast_yamaha/pymusiccast.py
+++ b/custom_components/musiccast_yamaha/pymusiccast.py
@@ -267,3 +267,24 @@ class Zone(Zone):
         payload = {'group_id': '',
                    'zone': self._zone_id}
         request(req_url, method='POST', json=payload)
+
+    def handle_message(self, message):
+        """Process UDP messages"""
+        if self._yamaha:
+            if 'power' in message:
+                _LOGGER.debug("Power: %s", message.get('power'))
+                self._yamaha.power = (
+                    STATE_ON if message.get('power') == "on" else STATE_OFF)
+            if 'input' in message:
+                _LOGGER.debug("Input: %s", message.get('input'))
+                self._yamaha._source = message.get('input')
+            if 'volume' in message:
+                volume = message.get('volume')
+                _LOGGER.debug("Volume: %d", volume)
+
+                self._yamaha.volume = volume / 100
+            if 'mute' in message:
+                _LOGGER.debug("Mute: %s", message.get('mute'))
+                self._yamaha.mute = message.get('mute', False)
+        else:
+            _LOGGER.debug("No yamaha-obj found")


### PR DESCRIPTION
My Yamaha R-N402D has a max_volume of 80 set which I cannot increase. The current code includes a calculation for the volume based on the max_volume, which does not work for me (the HA volume never corresponds to the device volume). I opened an issue 1,5 years ago in the Home Assistant repo (see https://github.com/home-assistant/core/issues/21218).

I decided to fix this now myself in this fork, as I don't think the core component will get updated anytime soon (because the change needs to be made in pymusiccast as well which is unmaintained).