### PR TITLE
Fix updating ha state

### DIFF
--- a/custom_components/musiccast_yamaha/media_player.py
+++ b/custom_components/musiccast_yamaha/media_player.py
@@ -284,7 +284,7 @@ class YamahaDevice(MediaPlayerEntity):
         """Push updates to Home Assistant."""
         if self.entity_id:
             _LOGGER.debug("update_hass: pushing updates")
-            self.schedule_update_ha_state()
+            self.schedule_update_ha_state(True)
             return True
         return False
 


### PR DESCRIPTION
This fixes #19. `True` must be passed to `schedule_update_ha_state` for hass to call `update` method before updating it's internal state.